### PR TITLE
fix env bug

### DIFF
--- a/bin/zxing
+++ b/bin/zxing
@@ -12,7 +12,8 @@ java_args = [
   "org.jruby.Main"
 ]
 
-lib = File.expand_path('../../lib', __FILE__)
+root_path = File.expand_path('../../', __FILE__)
+lib = File.join(root_path, 'lib')
 $:.unshift(lib) unless $:.include?(lib)
 
 path = "#{lib}/zxing/server.rb"
@@ -22,4 +23,6 @@ ruby_args = [
   "-e", "ZXing::Server.start!(#{port})"
 ]
 
+gemfile = File.join(root_path, 'Gemfile')
+ENV['BUNDLE_GEMFILE'] = gemfile
 exec("java", *(java_args + ruby_args))

--- a/lib/zxing/version.rb
+++ b/lib/zxing/version.rb
@@ -1,3 +1,3 @@
 module ZXing
-  VERSION = "0.4.1"
+  VERSION = "0.4.2"
 end


### PR DESCRIPTION
When we call this gem in Neptune, see this error:
```
Bundler::GemNotFound: Could not find nokogiri-1.6.7.2 in any of the sources
      block in materialize at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/spec_set.rb:88
                      map! at org/jruby/RubyArray.java:2518
               materialize at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/spec_set.rb:81
                     specs at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/definition.rb:176
                 specs_for at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/definition.rb:236
           requested_specs at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/definition.rb:225
  block in requested_specs at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/runtime.rb:118
                     setup at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/runtime.rb:19
                     setup at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler.rb:100
                    <main> at /Users/peihan/.rvm/gems/ruby-2.3.3/gems/bundler-1.14.6/lib/bundler/setup.rb:20
                   require at org/jruby/RubyKernel.java:961
                    (root) at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:1
```

This reason is when this gem start JRuby, it find Neptune's Gemfile in JRuby and try to load all the gems in JRuby. To fix this bug, we can set ENV['BUNDLE_GEMFILE'] to gem itself's Gemfile.
