### PR TITLE
Feature: expose server object + retry when connection lost

### DIFF
--- a/lib/zxing/client.rb
+++ b/lib/zxing/client.rb
@@ -11,12 +11,23 @@ module ZXing
       DRbObject.new_with_uri("druby://127.0.0.1:#{port}")
     end
 
+    def self.remote_client
+      @remote_client
+    end
+
+    def self.kill!
+      if remote_client
+        Process.kill(:INT, remote_client.pid)
+      end
+    end
+
     private
 
     def self.setup_drb_server(port)
-      remote_client = IO.popen("#{ZXing::BIN} #{port}")
+      @remote_client = IO.popen("#{ZXing::BIN} #{port}")
+
       sleep 0.5 until responsive?(port)
-      at_exit { Process.kill(:INT, remote_client.pid) }
+      at_exit { kill! }
     end
 
     def self.responsive?(port)


### PR DESCRIPTION
Hello,

First, thanks for your fork. We couldn't get the base gem to work reliably but your fork does the trick 👍 

We needed some more features revolving around process handling, so here's a PR in case you may be interested in those.

- Expose the server object and the method used to kill it, so that the calling code can do it too;
- Allow to open a new connection when the current one is no longer working

Let me know if you have any comments on it, and thanks again!